### PR TITLE
ci: add alpine variant

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,6 +16,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - dockerfile: ./Dockerfile
+            image: ghcr.io/${{ github.repository }}
+            flavour: ""
+          - dockerfile: ./Dockerfile.alpine
+            image: ghcr.io/${{ github.repository }}
+            flavour: "-alpine"
     permissions:
       contents: read
       packages: write
@@ -47,7 +57,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=latest${{ matrix.flavour }}
 
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
@@ -56,6 +68,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,11 @@
+FROM telegraf:1.31-alpine@sha256:9f52c5e1ca21a0eae1d05d758904df4c8bc1aff7eca4f97f3134742347c45daa
+
+RUN apk add --quiet --no-cache \
+  sudo mtr lm-sensors smartmontools ipmitool nvme-cli && \
+  echo 'telegraf ALL=NOPASSWD:/usr/sbin/smartctl *' | tee    /etc/sudoers.d/telegraf && \
+  echo 'telegraf ALL=NOPASSWD:/usr/sbin/nvme *'     | tee -a /etc/sudoers.d/telegraf && \
+  echo 'telegraf ALL=NOPASSWD:/usr/bin/ipmitool *'  | tee -a /etc/sudoers.d/telegraf && \
+  echo "Done."
+
+LABEL org.opencontainers.image.source="https://github.com/influxdata/telegraf" \
+  org.opencontainers.image.url="https://github.com/golift/telegraf-docker"

--- a/hooks/build
+++ b/hooks/build
@@ -11,3 +11,10 @@ echo "Building ARM64."
 docker buildx build --load --tag current:arm64 --platform linux/arm64/v8 .
 echo "Building ARM32."
 docker buildx build --load --tag current:arm32 --platform linux/arm/v7 .
+
+echo "Building Alpine AMD64."
+docker buildx build --file Dockerfile.alpine --load --tag current-alpine:amd64 --platform linux/amd64 .
+echo "Building Alpine ARM64."
+docker buildx build --file Dockerfile.alpine --load --tag current-alpine:arm64 --platform linux/arm64/v8 .
+echo "Building Alpine ARM32."
+docker buildx build --file Dockerfile.alpine --load --tag current-alpine:arm32 --platform linux/arm/v7 .

--- a/hooks/push
+++ b/hooks/push
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 docker buildx build --push --tag "${IMAGE_NAME}" --platform linux/amd64,linux/arm64/v8,linux/arm/v7 .
+docker buildx build --push --tag "${IMAGE_NAME}-alpine" --platform linux/amd64,linux/arm64/v8,linux/arm/v7 .


### PR DESCRIPTION
The alpine based telegraf docker image results in a ~2x reduction in image size when compared with the debian based one (~275MB vs ~500MB).
Not sure if the docker hub hooks are set up properly, I'm not able to test them.